### PR TITLE
updated way in what skip items were calculated. if skip count was > 0…

### DIFF
--- a/pagingQuery.go
+++ b/pagingQuery.go
@@ -262,11 +262,14 @@ type PaginatedData struct {
 }
 
 // getSkip return calculated skip value for query
-func getSkip(page, limit int64) (skip int64) {
-	if page > 0 {
-		skip = (page - 1) * limit
-	} else {
-		skip = page
+func getSkip(page, limit int64) int64 {
+	page--
+	skip := page  * limit
+	skip--
+
+	if skip <= 0 {
+		skip = 0
 	}
-	return
+
+	return skip
 }

--- a/pagingQuery_test.go
+++ b/pagingQuery_test.go
@@ -165,3 +165,37 @@ func connect() (a *mongo.Database, b *mongo.Client) {
 	var db = session.Database(DatabaseName)
 	return db, session
 }
+
+func TestGetSkip(t *testing.T) {
+	tc := []struct {
+		limit    int64
+		page     int64
+		expected int64
+	}{
+		{
+			limit:    10,
+			page:     -1,
+			expected: 0,
+		},
+		{
+			limit:    10,
+			page:     1,
+			expected: 0,
+		}, {
+			limit:    10,
+			page:     2,
+			expected: 9,
+		}, {
+			limit:    10,
+			page:     3,
+			expected: 19,
+		},
+	}
+
+	for _, tt := range tc {
+		skip := getSkip(tt.page, tt.limit)
+		if skip != tt.expected {
+			t.Fatalf("expected skip to be %d, got %d", tt.expected, skip)
+		}
+	}
+}


### PR DESCRIPTION
Fix bug with skip number (`func getSkip()`). 
If skipped value is grater than 0, it should be decreased by one, sine indexes in slice starting from 0
