### PR TITLE
Correct the offset calculation

### DIFF
--- a/pagination.go
+++ b/pagination.go
@@ -60,7 +60,7 @@ func Paging(p *pagingQuery, paginationInfo chan<- *Paginator, aggregate bool, ag
 	}
 
 	if p.PageCount > 0 {
-		offset = (p.PageCount - 1) * p.LimitCount
+		offset = ((p.PageCount - 1) * p.LimitCount) + 1
 	} else {
 		offset = 0
 	}


### PR DESCRIPTION
The offset wasn't correct and the last result from the previous page was included as the first result in a subsequent page.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- Create records which are a certain number e.g. 22
- send a request for page 1, limit 15. Note 15 records are correctly returned
- send another request for page 2, limit 15 and note there are 8 records where there should be 7. Record number 15 is repeated in both result sets.
- The correct offset for page 2, limit 15 is 16 so the calculation is limit-1 = 2 * offset 15 which is 15 + 1 which is 16. 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules